### PR TITLE
Refactor: project structure and modularize code

### DIFF
--- a/myte/constants.py
+++ b/myte/constants.py
@@ -1,0 +1,10 @@
+# constants.py
+
+"""
+This module defines constants use for this project
+"""
+
+import os
+
+template_folder = os.path.join(os.path.dirname(__file__), "templates")
+current_dir = os.getcwd()

--- a/myte/create_project.py
+++ b/myte/create_project.py
@@ -1,115 +1,44 @@
 # create_project.py
 
 """
-This module defines all functions and classes to create the boilerplate.
+This module defines the functions that create the boilerplate.
 """
 
 import os
 import shutil
 
-import inquirer
-import typer
+from constants import current_dir, template_folder
 from rich import print as mprint
-from rich.prompt import Prompt
 
 
 class CreateProject:
-    """ This class defines the project creation """
+    """ This class defines the boilerplate creation """
 
     @staticmethod
-    def project_setup():
-        """ This function defines the project creation """
+    def create_dir(project_name, selected_setup):
+        """ This function defines the creation of directory """
 
-        # create directory
-        def create_dir(project_name):
-            """ This function defines the creation of directory """
+        source_folder = os.path.join(template_folder,
+                                        f"template-flask-{selected_setup['setup']}")  # noqa
+        destination_folder = os.path.join(current_dir, project_name)
+        shutil.copytree(source_folder, destination_folder)
 
-            project_folder = os.path.abspath(f"{project_name}")
-            create_dir = shutil.copytree(template_folder, project_folder)
-            mprint("[blue]Successful[/blue]")
+        mprint("[blue]Successful[/blue]")
 
-            mprint(f"""
+        mprint(f"""
 [yellow]Usage:[/yellow]
 - cd into {project_name}
 
 - pip install virtualenv (if not installed)
 
 - create a virtual environment
-    [magenta]* windows: virtualenv env
-    * linux: python3 -m virtualenv env[/magenta]
+[magenta]* windows: virtualenv env
+* linux: python3 -m virtualenv env[/magenta]
 
 - activate virtual environment
-    [magenta]* windows: source .env/scripts/activate
-    * linux: source .env/bin/activate[/magenta]
+[magenta]* windows: source .env/scripts/activate
+* linux: source .env/bin/activate[/magenta]
 
 - run `pip install -r requirements`
-""")
-
-            return create_dir
-
-        # delete directory
-        def delete_dir(project_name):
-            """ This function defines the deletion of directory to override """
-
-            if os.path.exists(project_name):
-                mprint(
-                    f"[red]Folder '{project_name}' already exists.[/red]")
-                confirmation = typer.confirm("Do you want to override existing files?")  # noqa
-
-                if not confirmation:
-                    mprint("[red]The programme will now terminate[/red] [blink][/blink]")  # noqa
-                    raise typer.Abort()
-
-                delete_dir = shutil.rmtree(os.path.abspath(f"{project_name}"))
-
-                return delete_dir
-
-        # get project name
-        project_name = Prompt.ask(
-            "Project Name", default="myte-project")
-        mprint(f"[green]✅[/green] Project name: {project_name}")
-
-        # get framework choice
-        frameworks_choice = ["Flask", "Flask-Restful-API"]
-        frameworks = [
-            inquirer.List(
-                "framework",
-                message="Select a framework",
-                choices=frameworks_choice,
-                carousel=True,
-            )
-        ]
-        selected_framework = inquirer.prompt(frameworks)
-        mprint(f"[green]✅[/green] {selected_framework['framework']},  selected")  # noqa
-
-        # get setup choice
-        setup_choice = ["Simple", "Moderate", "Robust"]
-        setups = [
-            inquirer.List(
-                "setup",
-                message="Select a framework",
-                choices=setup_choice,
-                carousel=True,
-            )
-        ]
-        selected_setup = inquirer.prompt(setups)
-        mprint(f"[green]✅[/green] {selected_setup['setup']},  selected")  # noqa
-
-        # boilerplate execution
-        if project_name and selected_framework['framework'] and selected_setup['setup']:  # noqa
-
-            if selected_framework['framework'] == "Flask":  # noqa
-                if selected_setup['setup'] == "Simple":
-                    delete_dir(project_name)
-                    template_folder = os.path.abspath("../personals/myte/myte/templates/template-flask-simple")  # noqa
-                    create_dir(project_name)
-
-                if selected_setup['setup'] == "Moderate":  # noqa
-                    delete_dir(project_name)
-                    template_folder = os.path.abspath("../personals/myte/myte/templates/template-flask-moderate")  # noqa
-                    create_dir(project_name)
-
-                if selected_setup['setup'] == "Robust":  # noqa
-                    delete_dir(project_name)
-                    template_folder = os.path.abspath("../personals/myte/myte/templates/template-flask-robust")  # noqa
-                    create_dir(project_name)
+"""
+               )

--- a/myte/delete_project.py
+++ b/myte/delete_project.py
@@ -1,0 +1,31 @@
+# delete_project.py
+
+"""
+This module defines delete/override function for .
+"""
+
+import os
+import shutil
+
+import typer
+from rich import print as mprint
+
+
+class DeleteProject:
+    """ This class defines the project deletion/override function """
+
+    @staticmethod
+    def delete_dir(project_name):
+        """ This function defines the deletion/override of a directory  """
+
+        if os.path.exists(project_name):
+            mprint(
+                f"[red]Folder '{project_name}' already exists.[/red]")
+
+            confirmation = typer.confirm("Do you want to override existing files?")  # noqa
+
+            if not confirmation:
+                mprint("[red]The programme will now terminate[/red] [blink][/blink]")  # noqa
+                raise typer.Abort()
+
+            shutil.rmtree(os.path.abspath(f"{project_name}"))

--- a/myte/main.py
+++ b/myte/main.py
@@ -7,14 +7,13 @@ All configurations are done here.
 
 import typer
 from rich import print as mprint
+from setup_project import SetupProject
 
-from create_project import CreateProject
-
-# app initialization
+# cli initialization
 
 myte = typer.Typer()
 
-# application
+# cli start point
 
 
 @myte.command()
@@ -35,7 +34,7 @@ update your python version. [yellow]Thank you[/yellow]
 
         raise typer.Abort()
 
-    CreateProject.project_setup()
+    SetupProject.project_setup()
 
 
 # app run

--- a/myte/setup_project.py
+++ b/myte/setup_project.py
@@ -1,0 +1,66 @@
+# setup_project.py
+
+"""
+This module defines a function to create the boilerplate.
+"""
+
+import inquirer
+from create_project import CreateProject
+from delete_project import DeleteProject
+from rich import print as mprint
+from rich.prompt import Prompt
+
+
+class SetupProject:
+    """ This class defines the project creation """
+
+    @staticmethod
+    def project_setup():
+        """ This function defines the setup for the biolerplate creation """
+
+        # get project name
+        project_name = Prompt.ask(
+            "Project Name", default="myte-project")
+        mprint(f"[green]✅[/green] Project name: {project_name}")
+
+        # get framework choice
+        frameworks_choice = ["Flask", "Flask-Restful-API"]
+        frameworks = [
+            inquirer.List(
+                "framework",
+                message="Select a framework",
+                choices=frameworks_choice,
+                carousel=True,
+            )
+        ]
+        selected_framework = inquirer.prompt(frameworks)
+        mprint(f"[green]✅[/green] {selected_framework['framework']},  selected")  # noqa
+
+        # get setup choice
+        setup_choice = ["Simple", "Moderate", "Robust"]
+        setups = [
+            inquirer.List(
+                "setup",
+                message="Select a framework",
+                choices=setup_choice,
+                carousel=True,
+            )
+        ]
+        selected_setup = inquirer.prompt(setups)
+        mprint(f"[green]✅[/green] {selected_setup['setup']},  selected")  # noqa
+
+        # boilerplate execution
+        if project_name and selected_framework['framework'] and selected_setup['setup']:  # noqa
+
+            if selected_framework['framework'] == "Flask":  # noqa
+                if selected_setup['setup'] == "Simple":
+                    DeleteProject.delete_dir(project_name)
+                    CreateProject.create_dir(project_name, selected_setup)
+
+                if selected_setup['setup'] == "Moderate":  # noqa
+                    DeleteProject.delete_dir(project_name)
+                    CreateProject.create_dir(project_name, selected_setup)
+
+                if selected_setup['setup'] == "Robust":  # noqa
+                    DeleteProject.delete_dir(project_name)
+                    CreateProject.create_dir(project_name, selected_setup)


### PR DESCRIPTION
This commit refactors the project structure and modularizes the codebase for better organization and maintainability. The main changes include:

Separating the project into multiple modules:
main.py remains the entry point of the application, but its functionality has been simplified to initialize the CLI and start the setup process using the SetupProject class. setup_project.py defines the setup process for creating the boilerplate. It takes user inputs for project name, framework choice, and setup choice. create_project.py contains the logic to create the project directory and copy the template files based on the user's choices. It also provides usage instructions. delete_project.py handles the option to delete/override an existing project directory if it already exists. constants.py defines constants such as the template folder and current directory, improving code readability.